### PR TITLE
Fixed path being appended to links

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -61,7 +61,7 @@ const Navbar = () => {
           {navbarData.map((item) => {
             return (
               <li key={item.id}>
-                <NavLink to={item.path}>
+                <NavLink to={`/${item.path}`}>
                   <span>{item.title}</span>
                 </NavLink>
               </li>

--- a/src/routes/KeyboardEncyclopediaRoutes.js
+++ b/src/routes/KeyboardEncyclopediaRoutes.js
@@ -41,10 +41,6 @@ const KeyboardEncyclopediaRoutes = (props) => {
       component: Stabilizers,
     },
     {
-      name: "switches",
-      component: Switches,
-    },
-    {
       name: "switches/cherry",
       component: Cherry,
     },
@@ -61,7 +57,7 @@ const KeyboardEncyclopediaRoutes = (props) => {
       component: DurockJWK,
     },
     {
-      name: "switch-modfications",
+      name: "switch-modifications",
       component: SwitchModifications,
     },
     {
@@ -88,6 +84,7 @@ const KeyboardEncyclopediaRoutes = (props) => {
 
   return (
     <>
+      <Route exact path={`${path}/switches`} component={Switches}/>
       {routes.map((route, index) => (
         <Route path={`${path}/${route.name}`} key={index} component={route.component} />
       ))}


### PR DESCRIPTION
Fixed by adding forward slash before the Navbar link paths, so that it refers to the base url rather than the previous path